### PR TITLE
Add default targetPath to indicator class

### DIFF
--- a/src/shimoku_api_python/resources/reports/charts/indicator.py
+++ b/src/shimoku_api_python/resources/reports/charts/indicator.py
@@ -18,6 +18,7 @@ class Indicator(Report):
         title=None,
         value=None,
         description=None,
+        targetPath=None,
         color='neutral',
         align='right',
         variant='default',


### PR DESCRIPTION

## Description

Added a new `targetPath` property to the `Indicator` class to support links in indicators. This allows the indicator to direct users to a specified URL when clicked.

## Motivation and Context

Solutions requested the ability to have clickable indicators that lead to external sources for more detailed information. By adding the `targetPath` property, we can enhance user interaction with the dashboard and provide additional context or data sources.

## Changes Made

-   Modified the `Indicator` class definition to include `targetPath` in `default_properties`.


```python
default_properties = dict(
    ...
    targetPath=None,  # <-- Added this line
    ...
)
```

-   Updated relevant methods to handle and process the `targetPath` property when provided.

## How to Test

1.  Create a new indicator with the `targetPath` property set.
2.  Render the indicator on the dashboard.
3.  Click on the indicator; it should redirect to the specified URL in `targetPath`.
4.  Test with and without the `targetPath` property to ensure both scenarios work as expected.

## Screenshots

[Link to Screenshot1 showing clickable indicator] [Link to Screenshot2 showing redirection to specified URL]

## Checklist

-   I have updated the documentation to reflect the changes I have made.
-   I have squashed my commits into a single commit.
-   I have followed the coding style used in the repository.

## Additional Context

This feature was proposed in Issue #123 and discussed in the developers' meeting on July 7th. We believe that adding this functionality will enhance the usability of the indicators, especially for dashboards that rely on external data sources.

----------

This is a fictional example. Adjustments might be needed based on the actual context and changes in the real scenario.