### PR TITLE
Modals work on subpaths

### DIFF
--- a/src/shimoku_api_python/api/plot_api.py
+++ b/src/shimoku_api_python/api/plot_api.py
@@ -327,10 +327,9 @@ class PlotApi:
         r_hash = self._get_hash_for_container(modal_name)
         modal: Optional[Modal] = await self._app.get_report(r_hash=r_hash)
         if not modal:
-            modal: Report = await self._app.create_report(Modal, r_hash=r_hash,
-                                                          properties={'width': width,
-                                                                      'height': height,
-                                                                      'open': open_by_default})
+            modal: Report = await self._app.create_report(
+                Modal, r_hash=r_hash, path=self._current_path,
+                properties={'width': width, 'height': height, 'open': open_by_default})
             logger.info(f'Created modal {modal_name} with id {modal["id"]}')
             return modal
         properties = {}


### PR DESCRIPTION
# Pull Request

## Description

Added the path argument when creating a modal

## Motivation and Context

Modals were breaking in subpaths

## Changes Made

The path argument is passed to the creation of the report modal

## How to Test

Using the plot testing suite

## Screenshots

Not necessary

## Checklist

Please ensure that you have completed the following tasks before submitting your pull request:

- [X] I have updated the documentation to reflect the changes I have made.
- [X] I have squashed my commits into a single commit.
- [X] I have followed the coding style used in the repository.

## Additional Context

Not necessary