### PR TITLE
hotfix/da 299 filter dependency warnings uvloop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,3 @@ starlette_graphene3~=0.6.0
 fastapi~=0.103.2
 websockets~=11.0.3
 python-dateutil~=2.8.2
-uvloop~=0.19.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,6 @@ install_requires =
     fastapi~=0.103.2
     websockets~=11.0.3
     python-dateutil~=2.8.2
-    uvloop~=0.19.0
 
 [options.packages.find]
 where = src

--- a/src/shimoku_api_python/local_server.py
+++ b/src/shimoku_api_python/local_server.py
@@ -20,8 +20,6 @@ import schema_classes
 import schema_parameter_classses
 from inspect import getmembers, isclass
 import aiohttp
-import asyncio
-import uvloop
 
 print_paths = True
 

--- a/src/shimoku_api_python/websockets_server.py
+++ b/src/shimoku_api_python/websockets_server.py
@@ -1,10 +1,12 @@
 import asyncio
 import graphene
 import queue
-import json
 import uuid
 from pydantic import BaseModel
+import warnings
+warnings.filterwarnings("ignore", module="pydantic")
 import strawberry
+warnings.filterwarnings("default", module="pydantic")
 from fastapi import FastAPI
 
 


### PR DESCRIPTION
# Pull Request

## Description

Solved uvloop and warning errors, also added pyscaffold commit and readme, this brings a conflict, maybe a force push is needed

## Motivation and Context

Windows users had errors with uvloop, and warnings appeared in every execution

## Changes Made

Ignored pydantic warnings when importing strawberry and removed uvloop from the project

## How to Test

With any execution

## Screenshots

Not necessary

## Checklist

Please ensure that you have completed the following tasks before submitting your pull request:

- [ ] I have updated the documentation to reflect the changes I have made.
- [ ] I have squashed my commits into a single commit. (I dont think these commits need to be squashed)
- [X] I have followed the coding style used in the repository.

## Additional Context

The other two commits are from the readme(master) and pyscaffold update(devel), by trying to join both branches there would allways be a conflict, so i thought that it was better to force commit to devel and not master